### PR TITLE
Fix the problem when evaluating a cell: Cannot find the kernel with the specified name "K1".

### DIFF
--- a/examples/document and examples.nb
+++ b/examples/document and examples.nb
@@ -80320,7 +80320,6 @@ Cell[TextData[StyleBox["For more details, please refer to the  paper  arXiv : \
 c0d40405e7c5"]
 }, Open  ]]
 },
-Evaluator->"K1",
 WindowSize->{1264, 647},
 WindowMargins->{{-8, Automatic}, {Automatic, 0}},
 Magnification:>1.25 Inherited,


### PR DESCRIPTION
The following problem, which will block the cell evaluation within [document and examples.nb](https://github.com/goodluck1982/SpaceGroupIrep/blob/main/examples/document%20and%20examples.nb), will be triggered:
```
Cannot find the kernel with the specified name "K1".
```
It can be fixed by simply deleting the corresponding culprit row.