### PR TITLE
Add some instructions for the installation and use of Spglib's Python interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ In a word, the package SpaceGroupIrep is a database and tool set for IRs of spac
 
 
 ## Installation
+Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib).
 Place the directory **SpaceGroupIrep** containing at least the four files, i.e. SpaceGroupIrep.wl, AbstractGroupData.wl, LittleGroupIrepData.wl, and allBCSkLGdat.mx, under any of the following paths:
 * `$InstallationDirectory`/AddOns/Packages/
 * `$InstallationDirectory`/AddOns/Applications/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In a word, the package SpaceGroupIrep is a database and tool set for IRs of spac
 
 
 ## Installation
-Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib). If a virtual environment is used to manage the Python versions, you should first activate the appropriate Python environment before installation of Spglib and use of `SpaceGroupIrep`. See [here](https://github.com/goodluck1982/SpaceGroupIrep/issues/13) for a more detailed description.
+Spglib's Python interface is used as an external dependency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib). If a virtual environment is used to manage the Python versions, you should first activate the appropriate Python environment before installation of Spglib and use of `SpaceGroupIrep`. See [here](https://github.com/goodluck1982/SpaceGroupIrep/issues/13) for a more detailed description.
 
 Place the directory **SpaceGroupIrep** containing at least the four files, i.e. SpaceGroupIrep.wl, AbstractGroupData.wl, LittleGroupIrepData.wl, and allBCSkLGdat.mx, under any of the following paths:
 * `$InstallationDirectory`/AddOns/Packages/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In a word, the package SpaceGroupIrep is a database and tool set for IRs of spac
 
 
 ## Installation
-Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib). If a virtual environment is used to manage the Python versions, you should first activate the appropriate Python environment before installation of Spglib.
+Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib). If a virtual environment is used to manage the Python versions, you should first activate the appropriate Python environment before installation of Spglib and use of `SpaceGroupIrep`.
 
 Place the directory **SpaceGroupIrep** containing at least the four files, i.e. SpaceGroupIrep.wl, AbstractGroupData.wl, LittleGroupIrepData.wl, and allBCSkLGdat.mx, under any of the following paths:
 * `$InstallationDirectory`/AddOns/Packages/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In a word, the package SpaceGroupIrep is a database and tool set for IRs of spac
 
 
 ## Installation
-Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib). If a virtual environment is used to manage the Python versions, you should first activate the appropriate Python environment before installation of Spglib and use of `SpaceGroupIrep`.
+Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib). If a virtual environment is used to manage the Python versions, you should first activate the appropriate Python environment before installation of Spglib and use of `SpaceGroupIrep`. See [here](https://github.com/goodluck1982/SpaceGroupIrep/issues/13) for a more detailed description.
 
 Place the directory **SpaceGroupIrep** containing at least the four files, i.e. SpaceGroupIrep.wl, AbstractGroupData.wl, LittleGroupIrepData.wl, and allBCSkLGdat.mx, under any of the following paths:
 * `$InstallationDirectory`/AddOns/Packages/

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ In a word, the package SpaceGroupIrep is a database and tool set for IRs of spac
 
 
 ## Installation
-### Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib). If a virtual environment is used to manage the Python versions, you should first activate the appropriate Python environment.
-### Place the directory **SpaceGroupIrep** containing at least the four files, i.e. SpaceGroupIrep.wl, AbstractGroupData.wl, LittleGroupIrepData.wl, and allBCSkLGdat.mx, under any of the following paths:
+Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib). If a virtual environment is used to manage the Python versions, you should first activate the appropriate Python environment before installation of Spglib.
+
+Place the directory **SpaceGroupIrep** containing at least the four files, i.e. SpaceGroupIrep.wl, AbstractGroupData.wl, LittleGroupIrepData.wl, and allBCSkLGdat.mx, under any of the following paths:
 * `$InstallationDirectory`/AddOns/Packages/
 * `$InstallationDirectory`/AddOns/Applications/
 * `$BaseDirectory`/Applications/

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ In a word, the package SpaceGroupIrep is a database and tool set for IRs of spac
 
 
 ## Installation
-Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib).
-Place the directory **SpaceGroupIrep** containing at least the four files, i.e. SpaceGroupIrep.wl, AbstractGroupData.wl, LittleGroupIrepData.wl, and allBCSkLGdat.mx, under any of the following paths:
+### Spglib's Python interface is used as a external depenency, so it should be first installed according to the guidance [here](https://spglib.github.io/spglib/python-spglib.html#python-spglib). If a virtual environment is used to manage the Python versions, you should first activate the appropriate Python environment.
+### Place the directory **SpaceGroupIrep** containing at least the four files, i.e. SpaceGroupIrep.wl, AbstractGroupData.wl, LittleGroupIrepData.wl, and allBCSkLGdat.mx, under any of the following paths:
 * `$InstallationDirectory`/AddOns/Packages/
 * `$InstallationDirectory`/AddOns/Applications/
 * `$BaseDirectory`/Applications/


### PR DESCRIPTION
Spglib's Python interface is used as an external dependency, so it should be first installed.